### PR TITLE
Fix group creation user/post issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,3 @@
 **Meta University Internship Program 2025**
 
 Project Plan: https://docs.google.com/document/d/1vNQNzT8_fTWdJuXJ9tGQTQziGGsSEb8sm781ow9e8tE/edit?usp=sharing
-

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -7,4 +7,4 @@
 
 /generated/prisma
 
-node_modules/
+node_modules

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   photo    String
   location String
   email    String?
-  groups   Group[]
+  groups   Group[] @default([])
 }
 
 model Group {
@@ -22,7 +22,7 @@ model Group {
   name     String
   img      String
   members  User[]
-  posts    Post[]
+  posts    Post[] @default([])
 }
 
 model Post {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import express, { NextFunction, Request, Response } from "express";
+import express from "express";
 import { Prisma, PrismaClient } from "@prisma/client";
 import { withAccelerate } from "@prisma/extension-accelerate";
 
@@ -39,7 +39,6 @@ app.get("/groups/:id", async (req, res, next): Promise<void> => {
 app.post("/groups", async (req, res, next): Promise<void> => {
   const { name, img, members, posts } = req.body;
   try {
-    //Need to bundle member and post data to add to groups
     const memberData = members?.map((user: Prisma.UserCreateInput) => {
       return {
         username: user?.username,
@@ -63,10 +62,7 @@ app.post("/groups", async (req, res, next): Promise<void> => {
         name,
         img,
         members: {
-          create: memberData,
-        },
-        posts: {
-          create: postData,
+          connect: memberData,
         },
       },
     });
@@ -149,7 +145,10 @@ app.get("/users", async (req, res, next): Promise<void> => {
 app.get("/users/:id", async (req, res, next): Promise<void> => {
   const { id } = req.params;
   try {
-    const user = await prisma.user.findUnique({ where: { id: Number(id) } });
+    const user = await prisma.user.findUnique({
+      where: { id: Number(id) },
+      include: { groups: true },
+    });
     res.json(user);
   } catch (error) {
     next(error);


### PR DESCRIPTION
#This Pull Request:
-Used Prismas "connect" functionality instead of "create", because models have relationship this lets me connect pre-existing users to groups. If a user doesn't exist it simply ignores that input from the body (there are issues when it's the only user attempted to be added but for the use case of this application this situation shouldn't ever come up)