### PR TITLE
Added UI and functionality for users to create new groups

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { Prisma, PrismaClient } from "@prisma/client";
 import { withAccelerate } from "@prisma/extension-accelerate";
-const cors = require('cors');
+const cors = require("cors");
 
 const prisma = new PrismaClient().$extends(withAccelerate());
 
@@ -16,7 +16,7 @@ const port: number = 3000;
 //  [GET] /groups
 app.get("/groups", async (req, res, next): Promise<void> => {
   try {
-    const groups = await prisma.group.findMany({include: {members: true}});
+    const groups = await prisma.group.findMany({ include: { members: true } });
     res.json(groups);
   } catch (error) {
     next(error);

--- a/frontend/src/components/GroupCard.jsx
+++ b/frontend/src/components/GroupCard.jsx
@@ -12,7 +12,7 @@ export default function GroupCard({ group, members }) {
           <img src={group.img} alt="Group Image" className="group-img" />
           <div className="member-list">
             <p className="member-list-title">Member List:</p>
-            {members.map((member) => {
+            {members?.map((member) => {
               return <MemberCard member={member} key={member.id} />;
             })}
           </div>

--- a/frontend/src/components/GroupList.jsx
+++ b/frontend/src/components/GroupList.jsx
@@ -1,9 +1,12 @@
 import "../styles/GroupList.css";
 import GroupCard from "./GroupCard";
 
-export default function GroupList({ groups }) {
+export default function GroupList({ groups, onOpen }) {
   return (
     <section className="group-list">
+      <button className="create-group-button" onClick={onOpen}>
+        Create
+      </button>
       {groups.map((group) => {
         return (
           <GroupCard

--- a/frontend/src/components/GroupModal.jsx
+++ b/frontend/src/components/GroupModal.jsx
@@ -1,0 +1,64 @@
+import "../styles/GroupModal.css";
+import { useState } from "react";
+import MemberSearch from "./MemberSearch";
+
+const defaultGroup = {
+  name: "",
+  img: "/default_group_pic.png",
+  members: [],
+};
+
+export default function GroupModal({ displayMode, onClose, onCreate }) {
+  const [newGroup, setNewGroup] = useState(defaultGroup);
+
+  const handleFileChange = (event) => {
+    if (event.target.files && event.target.files[0]) {
+      setNewGroup({
+        ...newGroup,
+        img: `/${event.target.files[0].name}`,
+      });
+    }
+  };
+
+  const handleInputChange = (evt) => {
+    setNewGroup({
+      ...newGroup,
+      [evt.target.name]: evt.target.value,
+    });
+  };
+
+  const handleSubmit = (evt) => {
+    evt.preventDefault();
+    onCreate(newGroup);
+    onClose();
+  };
+
+  return (
+    <section className={displayMode} onSubmit={handleSubmit}>
+      <form className="modal-content">
+        <span className="close" onClick={onClose}>
+          X
+        </span>
+        <h2>Create New Group:</h2>
+        <h4>Name:</h4>
+        <input
+          type="text"
+          name="name"
+          onChange={handleInputChange}
+          value={newGroup.name}
+          placeholder="New Group..."
+          required
+        />
+        <h4>Group Image:</h4>
+        <input type="file" onChange={handleFileChange} />
+        <h4>Add Members to Groups:</h4>
+        <MemberSearch />
+        <input
+          type="submit"
+          value="Create New Group"
+          className="submit-button"
+        />
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/components/MemberSearch.jsx
+++ b/frontend/src/components/MemberSearch.jsx
@@ -1,0 +1,5 @@
+import "../styles/MemberSearch.css";
+
+export default function MemberSearch() {
+  return <div></div>;
+}

--- a/frontend/src/components/PostModal.jsx
+++ b/frontend/src/components/PostModal.jsx
@@ -46,6 +46,7 @@ export default function PostModal({ displayMode, onPost, onClose }) {
           onChange={handleInputChange}
           value={newPost.title}
           placeholder="New post..."
+          required
         />
         <h4>Add Image:</h4>
         <input type="file" className="img-input" onChange={handleFileChange} />
@@ -58,7 +59,7 @@ export default function PostModal({ displayMode, onPost, onClose }) {
           placeholder="How did i get here..."
         />
         <br />
-        <input type="submit" value="Post It!" />
+        <input type="submit" value="Post It!" className="submit-button" />
       </form>
     </section>
   );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -86,3 +86,11 @@ h6 {
 button:hover {
   cursor: pointer;
 }
+
+.submit-button {
+  margin: 1em;
+  cursor: pointer;
+  border-radius: 30px;
+  border: none;
+  background-color: var(--secondary-color);
+}

--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -48,16 +48,16 @@ function GroupPage() {
         {"<--"}
       </Link>
       <PostList posts={group ? group.posts : []} onOpen={openModal} />
-      <PostModal
-        onPost={createPost}
-        displayMode={modalDisplay}
-        onClose={closeModal}
-      />
       <MembersList members={group ? group.members : []} />
       {
         //Calendar
       }
       <Footer />
+      <PostModal
+        onPost={createPost}
+        displayMode={modalDisplay}
+        onClose={closeModal}
+      />
     </main>
   );
 }

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -4,6 +4,7 @@ import { httpRequest } from "../utils/utils";
 import Header from "../components/Header";
 import Navagation from "../components/Navagation";
 import HomeDetails from "../components/HomeDetails";
+import GroupModal from "../components/GroupModal";
 import GroupList from "../components/GroupList";
 import Footer from "../components/Footer";
 
@@ -11,6 +12,7 @@ const BASE_URL = import.meta.env.VITE_BASE_URL;
 
 function HomePage() {
   const [groups, setGroups] = useState([]);
+  const [modalDisplay, setModalDisplay] = useState("modal-hidden");
 
   useEffect(() => {
     const GROUP_URL = new URL("groups", BASE_URL);
@@ -18,6 +20,20 @@ function HomePage() {
       setGroups(groupList);
     });
   }, []);
+
+  const createGroup = async (groupData) => {
+    const GROUP_URL = new URL("groups", BASE_URL);
+    const newGroup = await httpRequest(GROUP_URL, "POST", groupData);
+    setGroups([...groups, newGroup]);
+  };
+
+  const openModal = () => {
+    setModalDisplay("modal-display");
+  };
+
+  const closeModal = () => {
+    setModalDisplay("modal-hidden");
+  };
 
   return (
     <main>
@@ -27,9 +43,14 @@ function HomePage() {
       </div>
       <div className="home-content">
         <HomeDetails />
-        <GroupList groups={groups} />
+        <GroupList groups={groups} onOpen={openModal} />
       </div>
       <Footer />
+      <GroupModal
+        displayMode={modalDisplay}
+        onClose={closeModal}
+        onCreate={createGroup}
+      />
     </main>
   );
 }

--- a/frontend/src/styles/GroupCard.css
+++ b/frontend/src/styles/GroupCard.css
@@ -1,6 +1,6 @@
 .group-card {
   width: auto;
-  max-width: fit-content;
+  max-width: 400px;
   min-width: 15%;
   height: 20vh;
   margin: 5% auto;
@@ -10,6 +10,7 @@
   border: gray solid 2px;
   border-radius: 10px;
   box-shadow: 3px 6.1px 6.1px hsl(0deg 0% 0% / 0.41);
+  overflow: hidden;
 }
 
 .group-info {
@@ -18,8 +19,8 @@
 }
 
 .group-img {
-  width: 9em;
-  height: 9em;
+  width: 40%;
+  height: 40%;
   max-width: 100%;
   max-height: 100%;
 }
@@ -36,8 +37,8 @@
 }
 
 .member-card img {
-  width: 10%;
-  height: 10%;
+  width: 1em;
+  height: 1em;
   border-radius: 20px;
   margin-right: 1em;
 }

--- a/frontend/src/styles/GroupList.css
+++ b/frontend/src/styles/GroupList.css
@@ -20,3 +20,24 @@
   position: relative;
   z-index: 1;
 }
+
+.create-group-button {
+  font-size: large;
+  background-color: var(--primary-color);
+  margin: 1em auto;
+  border-radius: 30px;
+  border: none;
+  padding: 0 3em;
+  box-shadow: 10px 4px 10px 0px rgba(0, 0, 0, 0.79);
+  transition: 0.5s ease;
+}
+
+.create-group-button:hover {
+  box-shadow: 7px 4px 12px 0px rgba(0, 0, 0, 0.79);
+  transform: scale(1.05);
+}
+
+.create-group-button:active {
+  box-shadow: 2px 2px 4px 0px rgba(0, 0, 0, 0.79);
+  transform: scale(0.95);
+}

--- a/frontend/src/styles/GroupModal.css
+++ b/frontend/src/styles/GroupModal.css
@@ -1,0 +1,37 @@
+.modal-display {
+  display: block;
+  position: fixed;
+  left: 0;
+  top: 0;
+  z-index: 1;
+  width: 100%;
+  height: 100vh;
+  margin: auto;
+  background-color: rgb(0, 0, 0, 0.4);
+}
+
+.modal-hidden {
+  display: none;
+}
+
+.modal-content {
+  background-color: var(--primary-color);
+  margin: 5% auto; /* 15% from the top and centered */
+  padding: 1%;
+  border: 1px solid #888;
+  width: 100%;
+  max-width: 600px;
+  height: auto;
+
+  border-radius: 30px;
+  box-shadow: 10px 10px 5px rgb(79, 79, 79);
+  overflow-y: auto;
+  text-align: center;
+  align-items: center;
+}
+
+.close {
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}

--- a/frontend/src/styles/PostList.css
+++ b/frontend/src/styles/PostList.css
@@ -19,7 +19,7 @@
 }
 
 .add-post-button {
-  background-color: #5ce65c;
+  background-color: var(--primary-color);
   margin: 1em auto;
   border-radius: 30px;
   border: none;


### PR DESCRIPTION
#This Pull Request
-Added button and form UI for users to add new boards to the page.
-Users can enter and name and image to create the new board.

-Added button at top of group list so it's easy to access and create new groups
<img width="567" alt="Screenshot 2025-06-27 at 4 19 31 PM" src="https://github.com/user-attachments/assets/3d21fe02-4fe5-467e-b522-938e253d9f39" />

-Similar modal to post modal, however I want to add a member search feature at the bottom so that when creating groups users can search through other users and click to choose which members to include in the new group
<img width="970" alt="Screenshot 2025-06-27 at 4 19 36 PM" src="https://github.com/user-attachments/assets/fce00de3-0bcc-4f59-acb0-e09e27b42c93" />

#Next Pull Request
-Add the search user feature to the create board modal and implement on click functionality to include users into the new group
