### PR TITLE
Searching groups feature implemented with a new provider and hook

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -37,8 +37,16 @@ const port: number = 3000;
 
 //  [GET] /groups
 app.get("/api/groups", async (req, res, next): Promise<void> => {
+  const query = req.query;
+  const name: string = query.name! as string;
+  console.log(name);
   try {
-    const groups = await prisma.group.findMany({ include: { members: true } });
+    const groups = await prisma.group.findMany({
+      where: {
+        name: { contains: name },
+      },
+      include: { members: true },
+    });
     res.json(groups);
   } catch (error) {
     next(error);

--- a/frontend/src/components/Navagation.jsx
+++ b/frontend/src/components/Navagation.jsx
@@ -1,11 +1,32 @@
 import "../styles/Navagation.css";
+import { useState } from "react";
+import useSearch from "../hooks/useSearch.js";
 
-export default function Navagation() {
+export default function Navagation({ onSearch, onClear }) {
+  const [searchedTerm, setSearchedTerm] = useState("");
+  const { setSearchTerm } = useSearch();
+
+  const handleSearch = () => {
+    setSearchTerm(searchedTerm);
+    onSearch();
+  };
+
+  const handleClear = () => {
+    setSearchedTerm("");
+    onClear();
+  };
+
   return (
     <div>
-      <input type="text" placeholder="Search..." className="search-bar" />
-      <button>X</button>
-      <button>Search</button>
+      <input
+        type="text"
+        placeholder="Search..."
+        className="search-bar"
+        value={searchedTerm}
+        onChange={(e) => setSearchedTerm(e.target.value)}
+      />
+      <button onClick={handleClear}>X</button>
+      <button onClick={handleSearch}>Search</button>
     </div>
   );
 }

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,0 +1,15 @@
+import GrouopCard from "./GroupCard";
+import "../styles/SearchResults.css";
+import useSearch from "../hooks/useSearch.js";
+
+export default function SearchResults() {
+  const { groups } = useSearch();
+
+  return (
+    <div className="search-results">
+      {groups?.map((group) => (
+        <GrouopCard group={group} members={group.members} key={group.id} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { searchResultsContext } from "../providers/SearchResultsProvider.jsx";
+
+export default function useSearch() {
+  //Make API request given search term
+  //Return the groups found
+  const { searchTerm, setSearchTerm, groups } =
+    useContext(searchResultsContext);
+
+  return { searchTerm, setSearchTerm, groups };
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,6 +8,7 @@ import { GroupProvider } from "./providers/GroupProvider.jsx";
 import { UserProvider } from "./providers/UserProvider.jsx";
 import { UserGroupProvider } from "./providers/UserGroupsProvider.jsx";
 import { AuthProvider } from "./providers/AuthProvider.jsx";
+import { SearchResultsProvider } from "./providers/SearchResultsProvider.jsx";
 import ProtectedRoute from "./components/ProtectedRoute.jsx";
 import useUser from "./hooks/useUser.js";
 import LoginPage from "./pages/LoginPage.jsx";
@@ -45,9 +46,11 @@ createRoot(document.getElementById("root")).render(
   <AuthProvider>
     <UserProvider>
       <UserGroupProvider>
-        <GroupProvider>
-          <AppRoutes />
-        </GroupProvider>
+        <SearchResultsProvider>
+          <GroupProvider>
+            <AppRoutes />
+          </GroupProvider>
+        </SearchResultsProvider>
       </UserGroupProvider>
     </UserProvider>
   </AuthProvider>,

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -6,13 +6,16 @@ import Navagation from "../components/Navagation";
 import HomeDetails from "../components/HomeDetails";
 import GroupModal from "../components/GroupModal";
 import GroupList from "../components/GroupList";
+import SearchResults from "../components/SearchResults.jsx";
 import Footer from "../components/Footer";
 import { userGroupContext } from "../providers/UserGroupsProvider.jsx";
+import useSearch from "../hooks/useSearch.js";
 
 const GROUP_URL = "/api/groups";
 
 function useCreateGroup() {
   const [isLoading, setIsLoading] = useState(true);
+
   const { groups, setGroups } = useContext(userGroupContext);
   const create = useCallback(
     (groupData) => {
@@ -33,6 +36,7 @@ function useCreateGroup() {
 
 function HomePage() {
   const [modalDisplay, setModalDisplay] = useState("modal-hidden");
+  const [searching, setSearching] = useState(false);
   const [createGroup] = useCreateGroup();
 
   const openModal = () => {
@@ -43,22 +47,34 @@ function HomePage() {
     setModalDisplay("modal-hidden");
   };
 
+  const startSearch = (searchTerm) => {
+    setSearching(true);
+  };
+
+  const endSearch = () => {
+    setSearching(false);
+  };
+
   return (
     <main>
       <Header />
       <div className="search-form">
-        <Navagation />
+        <Navagation onSearch={startSearch} onClear={endSearch} />
       </div>
-      <div className="home-content">
-        <HomeDetails />
-        <GroupList onOpen={openModal} />
-      </div>
+      {searching ? (
+        <SearchResults />
+      ) : (
+        <div className="home-content">
+          <HomeDetails />
+          <GroupList onOpen={openModal} />
+          <GroupModal
+            displayMode={modalDisplay}
+            onClose={closeModal}
+            onCreate={createGroup}
+          />
+        </div>
+      )}
       <Footer />
-      <GroupModal
-        displayMode={modalDisplay}
-        onClose={closeModal}
-        onCreate={createGroup}
-      />
     </main>
   );
 }

--- a/frontend/src/providers/SearchResultsProvider.jsx
+++ b/frontend/src/providers/SearchResultsProvider.jsx
@@ -1,0 +1,30 @@
+import { createContext, useEffect, useState } from "react";
+import { httpRequest } from "../utils/utils.js";
+import useSearch from "../hooks/useSearch.js";
+
+const searchResultsContext = createContext();
+
+function SearchResultsProvider({ children }) {
+  const [groups, setGroups] = useState([]);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const SEARCH_URL = `/api/groups/?name=${searchTerm}`;
+
+  useEffect(() => {
+    httpRequest(SEARCH_URL, "GET").then((groups) => {
+      setGroups(groups);
+    });
+  }, [searchTerm]);
+
+  useEffect(() => {});
+
+  return (
+    <searchResultsContext.Provider
+      value={{ groups, searchTerm, setSearchTerm }}
+    >
+      {children}
+    </searchResultsContext.Provider>
+  );
+}
+
+export { searchResultsContext, SearchResultsProvider };

--- a/frontend/src/styles/SearchResults.css
+++ b/frontend/src/styles/SearchResults.css
@@ -1,0 +1,6 @@
+.search-results {
+    margin: auto;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+}


### PR DESCRIPTION
# This Pull Request
-Implements the Group Search feature which allows users to search for any of the groups in the group database
-Adds a new hook so that the search results and term were easily accessible and changeable from anywhere
-Creates a Search Results component which the homepage will switch too when a user enters a search term and will be replaced by the normal home screen when the user clears their search

## Example:
-Here I searched for groups that contained the string "New" and you can see how the normal home page is now changed to a list of search results
-Currently the search term is case sensitive (which I personally prefer), but this could be easily changed with an addition to the Prisma command.
<img width="1650" alt="Screenshot 2025-07-03 at 2 17 07 PM" src="https://github.com/user-attachments/assets/eaf4fcf3-54bc-47ce-a3de-942eaf35de59" />

-One other improvement that could be made is that currently the SearchResultsProvider runs with a useEffect so it will make an unnecessary API call on initial page render. I could us a isSearching provider like the authentication provider I made to make this call only happen when the user searches.

# Next Pull Request
-Add ability for users to join groups through a button on groups they search. When joined the group should: be added to the users list of groups,  appear on the main homepage when navigated back too, have some sort of affect to distinguish itself from groups the user hasn't joined.
