### PR TITLE
GraphQL

### DIFF
--- a/backend/node_modules/.package-lock.json
+++ b/backend/node_modules/.package-lock.json
@@ -3126,6 +3126,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/graphql": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.3.tgz",
+      "integrity": "sha512-UoCovaxbJIxagCvVfalfK7YaNhmxj3BQFRQ2RHQKLiu+9wNXhJnlbspsLHt/YQM99IaLUUFJNzCwzc6W0ypMeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -5439,6 +5446,181 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-graphql": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.12.0.tgz",
+      "integrity": "sha512-DwYaJQy0amdy3pgNtiTDuGGM2BLdj+YO2SgbKoLliCfuHv3VVTt7vNG/ZqK2hRYjtYHE2t2KB705EU94mE64zg==",
+      "deprecated": "This package is no longer maintained. We recommend using `graphql-http` instead. Please consult the migration document https://github.com/graphql/graphql-http#migrating-express-grpahql.",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-type": "^1.0.4",
+        "http-errors": "1.8.0",
+        "raw-body": "^2.4.1"
+      },
+      "engines": {
+        "node": ">= 10.x"
+      },
+      "peerDependencies": {
+        "graphql": "^14.7.0 || ^15.3.0"
+      }
+    },
+    "node_modules/express-graphql/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/http-errors": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/express-graphql/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6025,6 +6207,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/gtoken": {
       "version": "8.0.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,7 +15,9 @@
         "argon2": "^0.43.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "express-graphql": "^0.12.0",
         "google-auth-library": "^10.1.0",
+        "graphql": "^15.8.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0"
       },
@@ -26,6 +28,7 @@
         "@eslint/js": "^9.31.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
+        "@types/graphql": "^14.2.3",
         "@types/jest": "^30.0.0",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/morgan": "^1.9.10",
@@ -3229,6 +3232,13 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/graphql": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.3.tgz",
+      "integrity": "sha512-UoCovaxbJIxagCvVfalfK7YaNhmxj3BQFRQ2RHQKLiu+9wNXhJnlbspsLHt/YQM99IaLUUFJNzCwzc6W0ypMeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -5815,6 +5825,181 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-graphql": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.12.0.tgz",
+      "integrity": "sha512-DwYaJQy0amdy3pgNtiTDuGGM2BLdj+YO2SgbKoLliCfuHv3VVTt7vNG/ZqK2hRYjtYHE2t2KB705EU94mE64zg==",
+      "deprecated": "This package is no longer maintained. We recommend using `graphql-http` instead. Please consult the migration document https://github.com/graphql/graphql-http#migrating-express-grpahql.",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.7",
+        "content-type": "^1.0.4",
+        "http-errors": "1.8.0",
+        "raw-body": "^2.4.1"
+      },
+      "engines": {
+        "node": ">= 10.x"
+      },
+      "peerDependencies": {
+        "graphql": "^14.7.0 || ^15.3.0"
+      }
+    },
+    "node_modules/express-graphql/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/http-errors": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
+      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/express-graphql/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-graphql/node_modules/raw-body/node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-graphql/node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6401,6 +6586,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/graphql": {
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/gtoken": {
       "version": "8.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "@eslint/js": "^9.31.0",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/graphql": "^14.2.3",
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",
@@ -48,7 +49,9 @@
     "argon2": "^0.43.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "express-graphql": "^0.12.0",
     "google-auth-library": "^10.1.0",
+    "graphql": "^15.8.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0"
   }

--- a/backend/src/algorithim/optimalTimeSlot.ts
+++ b/backend/src/algorithim/optimalTimeSlot.ts
@@ -68,11 +68,11 @@ export default async function optimalTimeSlot(
           if (event.groupID === groupID) {
             continue startTimeLoop;
           }
-          let number = timeSlotMap.get(
+          let numberConflicts = timeSlotMap.get(
             new TimeSlot(event.start, event.end, event.groupID).toString(),
           )!;
-          numConflicts += number;
-          score += number;
+          numConflicts += numberConflicts;
+          score += numberConflicts;
         } else if (possibleTimeSlot.eventsOverlap(bufferedEvent)) {
           score += BUFFER_PENALTY;
         }

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -5,7 +5,7 @@ export const schema = buildSchema(`
   type Query {
     getUser(id: Int!): User
     allUsers: [User]!
-    getGroup(id: Int!): Group
+    group(id: Int!): Group
     allGroups: [Group]!
   }
   
@@ -35,6 +35,7 @@ export const schema = buildSchema(`
     averageOffsetUTC: Float!
     averageEventLength: Int!
     postFrequency: Float!
+    posts: [Post!]!
   }
   
   type Event {
@@ -44,6 +45,15 @@ export const schema = buildSchema(`
     end: Date!
     participants: [User!]!
     group: Group
+  }
+  
+  type Post {
+    id: ID!
+    title: String!
+    img: String!
+    description: String!
+    author: String!
+    group: Group!
   }
   
   scalar Date
@@ -66,7 +76,7 @@ export const resolvers = {
     const users = await prisma.user.findMany();
     return users;
   },
-  getGroup: async ({ id }: { id: number }) => {
+  group: async ({ id }: { id: number }) => {
     const group = await prisma.group.findUnique({
       where: { id },
       include: { members: true, events: true, posts: true },

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -20,7 +20,7 @@ export const schema = buildSchema(`
     circle: [User!]!
     inCircle: [User!]!
     groups: [Group!]!
-    events: [Event!]!
+    events: [Event!]
   }
   
   type Group {
@@ -45,6 +45,7 @@ export const schema = buildSchema(`
     end: Date!
     participants: [User!]!
     group: Group
+    groupID: Int
   }
   
   type Post {
@@ -79,12 +80,18 @@ export const resolvers = {
   group: async ({ id }: { id: number }) => {
     const group = await prisma.group.findUnique({
       where: { id },
-      include: { members: true, events: true, posts: true },
+      include: {
+        members: { include: { events: true } },
+        events: { include: { participants: true } },
+        posts: true,
+      },
     });
     return group;
   },
   allGroups: async () => {
-    const groups = await prisma.group.findMany({ include: { members: true } });
+    const groups = await prisma.group.findMany({
+      include: { members: true },
+    });
     return groups;
   },
 };

--- a/backend/src/graphql/schema.ts
+++ b/backend/src/graphql/schema.ts
@@ -1,0 +1,80 @@
+import { buildSchema } from "graphql";
+import { prisma } from "../prisma";
+
+export const schema = buildSchema(`
+  type Query {
+    getUser(id: Int!): User
+    allUsers: [User]!
+    getGroup(id: Int!): Group
+    allGroups: [Group]!
+  }
+  
+  type User {
+    id: ID!
+    username: String!
+    email: String!
+    password: String!
+    location: String!
+    photo: String!
+    offsetUTC: Int!
+    circle: [User!]!
+    inCircle: [User!]!
+    groups: [Group!]!
+    events: [Event!]!
+  }
+  
+  type Group {
+    id: ID!
+    name: String!
+    img: String!
+    members: [User!]!
+    tags: [String!]!
+    prompt: String!
+    promptLastUpdate: Date!
+    events: [Event!]!
+    averageOffsetUTC: Float!
+    averageEventLength: Int!
+    postFrequency: Float!
+  }
+  
+  type Event {
+    id: ID!
+    text: String!
+    start: Date!
+    end: Date!
+    participants: [User!]!
+    group: Group
+  }
+  
+  scalar Date
+`);
+
+export const resolvers = {
+  getUser: async ({ id }: { id: number }) => {
+    const user = await prisma.user.findUnique({
+      where: { id },
+      include: {
+        circle: true,
+        inCircle: true,
+        events: { include: { group: true } },
+        groups: { include: { members: true } },
+      },
+    });
+    return user;
+  },
+  allUsers: async () => {
+    const users = await prisma.user.findMany();
+    return users;
+  },
+  getGroup: async ({ id }: { id: number }) => {
+    const group = await prisma.group.findUnique({
+      where: { id },
+      include: { members: true, events: true, posts: true },
+    });
+    return group;
+  },
+  allGroups: async () => {
+    const groups = await prisma.group.findMany({ include: { members: true } });
+    return groups;
+  },
+};

--- a/backend/src/routes/graphql.ts
+++ b/backend/src/routes/graphql.ts
@@ -1,0 +1,14 @@
+import express from "express";
+import { graphqlHTTP } from "express-graphql";
+import { schema, resolvers } from "../graphql/schema";
+
+export const graphqlRouter = express.Router();
+
+graphqlRouter.use(
+  "/api/graphql",
+  graphqlHTTP({
+    schema: schema,
+    rootValue: resolvers,
+    graphiql: true,
+  }),
+);

--- a/backend/src/routes/groupEvents.ts
+++ b/backend/src/routes/groupEvents.ts
@@ -110,6 +110,8 @@ groupEventsRouter.post(
         }
       }
 
+      console.log(members.map((member: any) => ({ id: Number(member.id) })));
+
       const event = await prisma.event.create({
         data: {
           text: text,
@@ -121,7 +123,7 @@ groupEventsRouter.post(
             },
           },
           participants: {
-            connect: members.map((member: any) => ({ id: member.id })),
+            connect: members.map((member: any) => ({ id: Number(member.id) })),
           },
         },
         include: {
@@ -152,8 +154,12 @@ groupEventsRouter.put(
   isAuthenticated,
   async (req, res) => {
     const { groupId, eventId } = req.params;
-    const { text, start, end, members } = req.body;
+    const { text, start, end, participants } = req.body;
     try {
+      console.log(participants);
+      console.log(
+        participants.map((member: any) => ({ id: Number(member.id) })),
+      );
       const event = await prisma.event.update({
         where: { id: Number(eventId) },
         data: {
@@ -162,7 +168,9 @@ groupEventsRouter.put(
           end: new Date(end),
           groupID: Number(groupId),
           participants: {
-            connect: [members.map((member: any) => ({ id: member.id }))],
+            connect: participants.map((member: any) => ({
+              id: Number(member.id),
+            })),
           },
         },
       });

--- a/backend/src/routes/groupEvents.ts
+++ b/backend/src/routes/groupEvents.ts
@@ -110,8 +110,6 @@ groupEventsRouter.post(
         }
       }
 
-      console.log(members.map((member: any) => ({ id: Number(member.id) })));
-
       const event = await prisma.event.create({
         data: {
           text: text,
@@ -156,10 +154,6 @@ groupEventsRouter.put(
     const { groupId, eventId } = req.params;
     const { text, start, end, participants } = req.body;
     try {
-      console.log(participants);
-      console.log(
-        participants.map((member: any) => ({ id: Number(member.id) })),
-      );
       const event = await prisma.event.update({
         where: { id: Number(eventId) },
         data: {

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import { postsRouter } from "./posts";
 import { promptRouter } from "./prompt";
 import { userEventsRouter } from "./userEvents";
 import { groupEventsRouter } from "./groupEvents";
+import { graphqlRouter } from "./graphql";
 
 export const routes = express.Router();
 
@@ -16,3 +17,4 @@ routes.use(groupEventsRouter);
 routes.use(groupsRouter);
 routes.use(usersRouter);
 routes.use(postsRouter);
+routes.use(graphqlRouter);

--- a/frontend/src/components/GroupCalendar.jsx
+++ b/frontend/src/components/GroupCalendar.jsx
@@ -87,6 +87,11 @@ export default function GroupCalendar({ group, setGroup }) {
   };
 
   const editEvent = (eventData) => {
+    eventData = {
+      ...eventData,
+      participants: group.events.find((event) => event.id === eventData.id)
+        .participants,
+    };
     const EVENT_URL = `${import.meta.env.VITE_BASE_URL}/api/group/${group.id}/events/${eventData.id}`;
     httpRequest(EVENT_URL, "PUT", eventData);
   };

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -53,19 +53,25 @@ export function SearchResults() {
       <p className="p-4 text-sm text-gray-600 dark:text-gray-300">
         {groups ? `${groups.length} results found...` : "Loading results..."}
       </p>
-      <div className={"grid gap-4 sm:grid-cols-2 md:grid-cols-3"}>
-        {groups?.map((group) => (
-          <GroupCard
-            group={group}
-            members={group.members}
-            key={group.id}
-            joinedGroup={userGroups.some(
-              (userGroup) => userGroup.id === group.id,
-            )}
-            home={false}
-          />
-        ))}
-      </div>
+      {groups.length > 0 ? (
+        <div className={"grid gap-4 sm:grid-cols-2 md:grid-cols-3"}>
+          {groups?.map((group) => (
+            <GroupCard
+              group={group}
+              members={group.members}
+              key={group.id}
+              joinedGroup={userGroups.some(
+                (userGroup) => userGroup.id === group.id,
+              )}
+              home={false}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className={"flex flex-col items-center justify-center p-48"}>
+          <p className={"text-4xl font-bold"}>No results found</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/GroupPage.jsx
+++ b/frontend/src/pages/GroupPage.jsx
@@ -14,6 +14,9 @@ import BackButton from "../components/BackButtons.jsx";
 import GroupTimer from "../components/GroupTimer.jsx";
 import BridgeTheGapLoadingSpinner from "../components/BridgeTheGapLoadingSpinner.jsx";
 import useUser from "../hooks/useUser.js";
+import { createGroupQuery } from "../utils/querys.js";
+
+const GRAPHQL_URL = `${import.meta.env.VITE_BASE_URL}/api/graphql`;
 
 function GroupPage() {
   const params = useParams();
@@ -25,8 +28,9 @@ function GroupPage() {
   const [post, setPost] = useState(null);
 
   useEffect(() => {
-    const GROUP_URL = `${import.meta.env.VITE_BASE_URL}/api/groups/${params.id}`;
-    httpRequest(GROUP_URL, "GET").then((group) => {
+    const query = createGroupQuery(params.id);
+    httpRequest(GRAPHQL_URL, "POST", { query }).then((response) => {
+      const { group } = response.data;
       setGroup({
         ...group,
         events: group.events.map((event) => {

--- a/frontend/src/providers/GroupProvider.jsx
+++ b/frontend/src/providers/GroupProvider.jsx
@@ -5,6 +5,21 @@ import useAuth from "../hooks/useAuth.js";
 const groupContext = createContext();
 
 const GROUPS_URL = `${import.meta.env.VITE_BASE_URL}/api/groups`;
+const GRAPHQL_URL = `${import.meta.env.VITE_BASE_URL}/api/graphql`;
+
+const query = `
+query {
+  allGroups {
+    id
+    name
+    img
+    members {
+      id
+      username
+    }
+  }
+}
+`;
 
 function GroupProvider(props) {
   const [groups, setGroups] = useState([]);
@@ -15,9 +30,10 @@ function GroupProvider(props) {
     setIsLoading(true);
 
     if (!auth || loading) return;
-    httpRequest(GROUPS_URL, "GET")
-      .then((groupList) => {
-        setGroups(groupList);
+    httpRequest(GRAPHQL_URL, "POST", { query })
+      .then((response) => {
+        const { allGroups } = response.data;
+        setGroups(allGroups);
       })
       .finally(() => {
         setIsLoading(false);

--- a/frontend/src/utils/querys.js
+++ b/frontend/src/utils/querys.js
@@ -1,0 +1,27 @@
+export const createGroupQuery = (id) => {
+  return `
+  query {
+      group(id: ${id}) {
+        id
+        name
+        prompt
+        promptLastUpdate
+        averageOffsetUTC
+        members {
+          username
+          photo
+        }
+        posts {
+          title
+          img
+          description
+          author
+        }
+        events {
+          text
+          start
+          end
+        }
+        }
+      }`;
+};

--- a/frontend/src/utils/querys.js
+++ b/frontend/src/utils/querys.js
@@ -8,8 +8,15 @@ export const createGroupQuery = (id) => {
         promptLastUpdate
         averageOffsetUTC
         members {
+          id
           username
           photo
+          events {
+            start
+            end
+            groupID
+            text
+          }
         }
         posts {
           id
@@ -19,9 +26,13 @@ export const createGroupQuery = (id) => {
           author
         }
         events {
+          id
           text
           start
           end
+          participants {
+            id
+          }
         }
         }
       }`;

--- a/frontend/src/utils/querys.js
+++ b/frontend/src/utils/querys.js
@@ -12,6 +12,7 @@ export const createGroupQuery = (id) => {
           photo
         }
         posts {
+          id
           title
           img
           description


### PR DESCRIPTION
# This Pull Request
- Adds a GraphQL router, schema, and resolvers to the backend
- Sets up GraphQL schema to mirror the Prisma schema as much as possible
- Implements a basic client side GraphQL request to replace the "/api/group/:groupID" route

## Milestones
Stretch: Add GraphQL to modernize API interface

## Resources
<https://graphql.org/learn/schema-design/>

## Description
- I use the defined GraphQL schema I created to reimplement the "/api/group/:groupID" route and replace it with a "/api/graphql" route instead. I define a createGroupQuery function to handle the construction of the request body and pass this all into the backend. I'm now able to limit the data my API responds with to not over fetch unnecessary data. 

# Next Pull Request
- I'm going to try and wrap my fetch requests in DataLoader to limit the latency cause by the excessive promises created through GraphQL's fetching.
